### PR TITLE
Fix release version fetching

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,7 +48,7 @@ error() {
 }
 
 # Fetch the latest release tag from GitHub API
-LATEST_RELEASE=$(curl -s $REPO_URL | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+curl -s $REPO_URL | grep -o '"tag_name": *"[^"]*"' | sed 's/.*": *"\([^"]*\)".*/\1/'
 
 echo ""
 info "Latest release: $LATEST_RELEASE"

--- a/install.sh
+++ b/install.sh
@@ -48,7 +48,7 @@ error() {
 }
 
 # Fetch the latest release tag from GitHub API
-curl -s $REPO_URL | grep -o '"tag_name": *"[^"]*"' | sed 's/.*": *"\([^"]*\)".*/\1/'
+LATEST_RELEASE=$(curl -s $REPO_URL | grep -o '"tag_name": *"[^"]*"' | sed 's/.*": *"\([^"]*\)".*/\1/')
 
 echo ""
 info "Latest release: $LATEST_RELEASE"


### PR DESCRIPTION
Previously this was returning the `body` of the API response, which caused installation to fail. Now it returns the version number.

This could be done much cleaner with `jq`, but I'm assuming you'd rather not introduce that dependency.